### PR TITLE
Upload Root Token and Vault URi

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -84,7 +84,8 @@
                 "env": {
                     
                     "VAULT_ADDRESS": "http://127.0.0.1:8200",
-                    "ENVIRONMENT": "Dev"
+                    "ENVIRONMENT": "Dev",
+                    "UPLOAD_TOKEN": "TRUE"
                 },
                 "volumes": [
                     {

--- a/VaultConfig/Program.cs
+++ b/VaultConfig/Program.cs
@@ -35,7 +35,13 @@ namespace VaultConfig
             string yamlFilePath = Environment.GetEnvironmentVariable("CONFIG_FILE");
             string environment = Environment.GetEnvironmentVariable("ENVIRONMENT");
             string importFile = Environment.GetEnvironmentVariable("IMPORT_FILE");
-            
+
+            string uploadUriAndRootToken = Environment.GetEnvironmentVariable("UPLOAD_TOKEN");
+
+            bool uploadRootToken = false;
+            if(uploadUriAndRootToken != null && uploadUriAndRootToken.ToLower() == "true")
+                uploadRootToken = true;
+
             if(yamlFilePath is null)
                 yamlFilePath = "/config/config.yml";
 
@@ -51,10 +57,11 @@ namespace VaultConfig
             if(environment != "Dev")
                 Thread.Sleep(5000);
 
-            VaultConfigurer vaultConfigurer = new VaultConfigurer(rootTokenFile, vaultAddress, yamlFilePath);
+            VaultConfigurer vaultConfigurer = new VaultConfigurer(rootTokenFile, vaultAddress, yamlFilePath, uploadRootToken);
             vaultConfigurer.CreateAuth();
             vaultConfigurer.CreateAccess();
             vaultConfigurer.CreateSecrets();
+
             if(File.Exists(importFile))
             {
                 Log.Information("Import File has been found at " + importFile);    


### PR DESCRIPTION
This PR will allow the vault address used and the root token to be added as secrets to vault.

This will make it easier to access the root token should it be needed for something such as an automated workflow or for testing.